### PR TITLE
BENCH-23 - Add dark theme support, splash screen loading

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,4 +105,10 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation "org.mockito:mockito-core:2.21.0"
 
+    // DataStore
+    implementation "androidx.datastore:datastore-preferences:1.0.0"
+
+    // Splash Screen
+    implementation 'androidx.core:core-splashscreen:1.0.0-beta01'
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,12 +9,12 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.CalorieCalc">
+        android:theme="@style/Theme.App.Starting">
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.CalorieCalc.NoActionBar">
+            android:theme="@style/Theme.App.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/epam/caloriecalc/MainActivity.kt
+++ b/app/src/main/java/com/epam/caloriecalc/MainActivity.kt
@@ -3,23 +3,45 @@ package com.epam.caloriecalc
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.*
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.navigation.compose.rememberNavController
+import com.epam.caloriecalc.ui.home.HomeViewModel
 import com.epam.caloriecalc.ui.navigation.NavBar
 import com.epam.caloriecalc.ui.navigation.NavBarGraph
 import com.epam.caloriecalc.ui.theme.CalorieCalcTheme
+import com.epam.caloriecalc.util.Constants.SETTINGS_THEME_DARK
+import com.epam.caloriecalc.util.Constants.SETTINGS_THEME_DEFAULT
+import com.epam.caloriecalc.util.Constants.SETTINGS_THEME_LIGHT
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    private val homeViewModel: HomeViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            CalorieCalcTheme {
+            val darkTheme by homeViewModel.themeMode.collectAsState(initial = SETTINGS_THEME_DEFAULT)
+            val splashScreen = installSplashScreen()
+            splashScreen.setKeepOnScreenCondition { homeViewModel.isLoading.value }
+
+            CalorieCalcTheme(
+                darkTheme = when (darkTheme) {
+                    SETTINGS_THEME_LIGHT -> false
+                    SETTINGS_THEME_DARK -> true
+                    else -> isSystemInDarkTheme()
+                }
+            ) {
                 val navController = rememberNavController()
                 Surface(color = MaterialTheme.colors.background) {
                     Scaffold(

--- a/app/src/main/java/com/epam/caloriecalc/data/settings/SettingsManager.kt
+++ b/app/src/main/java/com/epam/caloriecalc/data/settings/SettingsManager.kt
@@ -1,0 +1,38 @@
+package com.epam.caloriecalc.data.settings
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.epam.caloriecalc.util.Constants
+import com.epam.caloriecalc.util.Constants.SETTINGS_THEME_DEFAULT
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = Constants.SETTINGS_NAME)
+
+class SettingsManager @Inject constructor(
+   @ApplicationContext private val appContext: Context
+) {
+
+    private val settingsDataStore = appContext.dataStore
+
+    suspend fun setThemeMode(mode: Int) {
+        settingsDataStore.edit { settings ->
+            settings[PreferencesKeys.THEME_MODE_KEY] = mode
+        }
+    }
+
+    val themeMode: Flow<Int> = settingsDataStore.data.map { preferences ->
+        preferences[PreferencesKeys.THEME_MODE_KEY] ?: SETTINGS_THEME_DEFAULT
+    }
+
+
+    private object PreferencesKeys {
+        val THEME_MODE_KEY = intPreferencesKey("theme_mode_key")
+    }
+}

--- a/app/src/main/java/com/epam/caloriecalc/di/AppModule.kt
+++ b/app/src/main/java/com/epam/caloriecalc/di/AppModule.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import com.epam.caloriecalc.data.local.CalorieDatabase
 import com.epam.caloriecalc.data.local.repository.CalorieRepository
 import com.epam.caloriecalc.data.local.repository.CalorieRepositoryImpl
+import com.epam.caloriecalc.data.settings.SettingsManager
 import com.epam.caloriecalc.util.Constants
 import dagger.Module
 import dagger.Provides
@@ -30,5 +31,11 @@ object AppModule {
     @Singleton
     fun provideCalorieRepository(db: CalorieDatabase): CalorieRepository {
         return CalorieRepositoryImpl(db.dao)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSettingsManager(app: Application): SettingsManager {
+        return SettingsManager(app)
     }
 }

--- a/app/src/main/java/com/epam/caloriecalc/di/AppModule.kt
+++ b/app/src/main/java/com/epam/caloriecalc/di/AppModule.kt
@@ -19,23 +19,22 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideDatabase(app: Application): CalorieDatabase {
-        return Room.databaseBuilder(
+    fun provideDatabase(app: Application): CalorieDatabase =
+        Room.databaseBuilder(
             app,
             CalorieDatabase::class.java,
             Constants.CALORIE_DATABASE_NAME
         ).build()
-    }
 
     @Provides
     @Singleton
-    fun provideCalorieRepository(db: CalorieDatabase): CalorieRepository {
-        return CalorieRepositoryImpl(db.dao)
-    }
+    fun provideCalorieRepository(db: CalorieDatabase): CalorieRepository =
+        CalorieRepositoryImpl(db.dao)
+
 
     @Provides
     @Singleton
-    fun provideSettingsManager(app: Application): SettingsManager {
-        return SettingsManager(app)
-    }
+    fun provideSettingsManager(app: Application): SettingsManager =
+        SettingsManager(app)
+
 }

--- a/app/src/main/java/com/epam/caloriecalc/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/epam/caloriecalc/ui/home/HomeViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.viewModelScope
 import com.epam.caloriecalc.data.local.relations.IntakeWithProduct
 import com.epam.caloriecalc.data.local.repository.CalorieRepository
 import com.epam.caloriecalc.data.model.DailyStat
+import com.epam.caloriecalc.data.settings.SettingsManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -15,8 +17,13 @@ import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val repository: CalorieRepository
+    repository: CalorieRepository,
+    settingsManager: SettingsManager
 ) : ViewModel() {
+
+    val isLoading = MutableStateFlow(true)
+
+    val themeMode = settingsManager.themeMode
 
     val intakesTodayStats = MutableStateFlow(DailyStat())
 
@@ -27,7 +34,10 @@ class HomeViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
+            /* Delay for the splash screen loading */
+            delay(1000L)
             intakesTodayStats.value = calculateTodayStats(intakesToday.stateIn(this).value)
+            isLoading.value = false
         }
     }
 

--- a/app/src/main/java/com/epam/caloriecalc/ui/navigation/NavBarGraph.kt
+++ b/app/src/main/java/com/epam/caloriecalc/ui/navigation/NavBarGraph.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.epam.caloriecalc.ui.home.HomeScreen
+import com.epam.caloriecalc.ui.settings.SettingsScreen
 
 @Composable
 fun NavBarGraph(
@@ -21,7 +22,7 @@ fun NavBarGraph(
             //HistoryScreen()
         }
         composable(route = NavBarScreenType.Settings.route) {
-            //SettingsScreen()
+            SettingsScreen()
         }
 
     }

--- a/app/src/main/java/com/epam/caloriecalc/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/epam/caloriecalc/ui/settings/SettingsScreen.kt
@@ -1,35 +1,25 @@
 package com.epam.caloriecalc.ui.settings
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.DropdownMenu
-import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.epam.caloriecalc.R
+import com.epam.caloriecalc.ui.settings.components.DropdownMenuBox
 import com.epam.caloriecalc.ui.theme.Typography
+import com.epam.caloriecalc.util.Constants.SETTINGS_THEME_DARK
 import com.epam.caloriecalc.util.Constants.SETTINGS_THEME_DEFAULT
 import com.epam.caloriecalc.util.Constants.SETTINGS_THEME_LIGHT
-import com.epam.caloriecalc.util.Constants.SETTINGS_THEME_DARK
 
 @Composable
 fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
-
-    var expandedState by remember { mutableStateOf(false) }
 
     val themeItems =
         listOf(
@@ -63,42 +53,10 @@ fun SettingsScreen(
                 textDecoration = TextDecoration.Underline
             )
             Spacer(modifier = Modifier.width(8.dp))
-            Box(
-                contentAlignment = Alignment.CenterStart
-            ) {
-                Text(
-                    text = themeItems[selectedIndex].first,
-                    style = Typography.h6,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .border(
-                            border = BorderStroke(width = 2.dp, Color.Gray)
-                        )
-                        .padding(4.dp)
-                        .clickable(onClick = { expandedState = true })
-                )
-                DropdownMenu(
-                    expanded = expandedState,
-                    onDismissRequest = { expandedState = false },
-                    modifier = Modifier
-                        .fillMaxWidth(0.9f)
-                        .background(Color.Gray, shape = RoundedCornerShape(4.dp))
-                ) {
-                    themeItems.forEachIndexed { index, s ->
-                        DropdownMenuItem(onClick = {
-                            selectedIndex = index
-                            expandedState = false
-                        }) {
-                            Text(
-                                text = s.first,
-                                style = Typography.h6,
-                                textAlign = TextAlign.Center
-                            )
-                        }
-                    }
-                }
-            }
+            DropdownMenuBox(
+                items = themeItems,
+                savedIndex = viewModel.themeState.value,
+                onClick = { selectedIndex = it })
         }
     }
 }

--- a/app/src/main/java/com/epam/caloriecalc/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/epam/caloriecalc/ui/settings/SettingsScreen.kt
@@ -1,0 +1,104 @@
+package com.epam.caloriecalc.ui.settings
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.epam.caloriecalc.R
+import com.epam.caloriecalc.ui.theme.Typography
+import com.epam.caloriecalc.util.Constants.SETTINGS_THEME_DEFAULT
+import com.epam.caloriecalc.util.Constants.SETTINGS_THEME_LIGHT
+import com.epam.caloriecalc.util.Constants.SETTINGS_THEME_DARK
+
+@Composable
+fun SettingsScreen(
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+
+    var expandedState by remember { mutableStateOf(false) }
+
+    val themeItems =
+        listOf(
+            (stringResource(R.string.theme_device_default) to SETTINGS_THEME_DEFAULT),
+            (stringResource(R.string.theme_light) to SETTINGS_THEME_LIGHT),
+            (stringResource(R.string.theme_dark) to SETTINGS_THEME_DARK)
+        )
+
+    var selectedIndex by remember { mutableStateOf(viewModel.themeState.value) }
+
+    LaunchedEffect(key1 = selectedIndex) {
+        viewModel.changeThemeMode(themeItems[selectedIndex].second)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.Top
+        ) {
+            Text(
+                text = stringResource(R.string.appearance) + ":",
+                style = Typography.h5,
+                textDecoration = TextDecoration.Underline
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Box(
+                contentAlignment = Alignment.CenterStart
+            ) {
+                Text(
+                    text = themeItems[selectedIndex].first,
+                    style = Typography.h6,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .border(
+                            border = BorderStroke(width = 2.dp, Color.Gray)
+                        )
+                        .padding(4.dp)
+                        .clickable(onClick = { expandedState = true })
+                )
+                DropdownMenu(
+                    expanded = expandedState,
+                    onDismissRequest = { expandedState = false },
+                    modifier = Modifier
+                        .fillMaxWidth(0.9f)
+                        .background(Color.Gray, shape = RoundedCornerShape(4.dp))
+                ) {
+                    themeItems.forEachIndexed { index, s ->
+                        DropdownMenuItem(onClick = {
+                            selectedIndex = index
+                            expandedState = false
+                        }) {
+                            Text(
+                                text = s.first,
+                                style = Typography.h6,
+                                textAlign = TextAlign.Center
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/epam/caloriecalc/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/epam/caloriecalc/ui/settings/SettingsViewModel.kt
@@ -1,0 +1,32 @@
+package com.epam.caloriecalc.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.epam.caloriecalc.data.settings.SettingsManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val settingsManager: SettingsManager
+) : ViewModel() {
+
+    private val _themeState = MutableStateFlow(0)
+    val themeState = _themeState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            _themeState.value = settingsManager.themeMode.stateIn(viewModelScope).value
+        }
+    }
+
+    fun changeThemeMode(value: Int) {
+        viewModelScope.launch {
+            settingsManager.setThemeMode(value)
+        }
+    }
+}

--- a/app/src/main/java/com/epam/caloriecalc/ui/settings/components/DropdownMenuBox.kt
+++ b/app/src/main/java/com/epam/caloriecalc/ui/settings/components/DropdownMenuBox.kt
@@ -1,0 +1,72 @@
+package com.epam.caloriecalc.ui.settings.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.epam.caloriecalc.ui.theme.Typography
+
+@Composable
+fun DropdownMenuBox(
+    items: List<Pair<String, Int>>,
+    savedIndex: Int,
+    onClick: (Int) -> Unit
+) {
+    var expandedState by remember { mutableStateOf(false) }
+
+    var selectedIndex by remember { mutableStateOf(savedIndex) }
+
+    LaunchedEffect(key1 = selectedIndex) {
+        onClick(selectedIndex)
+    }
+
+    Box(
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Text(
+            text = items[selectedIndex].first,
+            style = Typography.h6,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .border(
+                    border = BorderStroke(width = 2.dp, Color.Gray)
+                )
+                .padding(4.dp)
+                .clickable(onClick = { expandedState = true })
+        )
+        DropdownMenu(
+            expanded = expandedState,
+            onDismissRequest = { expandedState = false },
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .background(Color.Gray, shape = RoundedCornerShape(4.dp))
+        ) {
+            items.forEachIndexed { index, item ->
+                DropdownMenuItem(onClick = {
+                    selectedIndex = index
+                    expandedState = false
+                }) {
+                    Text(
+                        text = item.first,
+                        style = Typography.h6,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/epam/caloriecalc/util/Constants.kt
+++ b/app/src/main/java/com/epam/caloriecalc/util/Constants.kt
@@ -7,4 +7,9 @@ object Constants {
     const val PRODUCT_TABLE_NAME = "product_table"
     const val PRODUCT_ID_COLUMN_NAME = "productId"
     const val PRODUCT_NAME_COLUMN_NAME = "name"
+
+    const val SETTINGS_NAME = "settings"
+    const val SETTINGS_THEME_DEFAULT = 0
+    const val SETTINGS_THEME_LIGHT = 1
+    const val SETTINGS_THEME_DARK = 2
 }

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -13,4 +13,8 @@
     <string name="screen_home">Kezdőlap</string>
     <string name="screen_history">Előzmények</string>
     <string name="screen_settings">Beállítások</string>
+    <string name="appearance">Kinézet</string>
+    <string name="theme_device_default">Alapértelmezett</string>
+    <string name="theme_light">Világos mód</string>
+    <string name="theme_dark">Sötét mód</string>
 </resources>

--- a/app/src/main/res/values/splash.xml
+++ b/app/src/main/res/values/splash.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.App.Starting" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">#0000</item>
+
+        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_foreground</item>
+
+        <item name="postSplashScreenTheme">@style/Theme.CalorieCalc</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,8 @@
     <string name="screen_home">Home</string>
     <string name="screen_history">History</string>
     <string name="screen_settings">Settings</string>
+    <string name="appearance">Appearance</string>
+    <string name="theme_device_default">Device default</string>
+    <string name="theme_light">Light mode</string>
+    <string name="theme_dark">Dark mode</string>
 </resources>


### PR DESCRIPTION
-Added simple Settings screen with dropdown selector for picking the theme
-Created Settings DataStore, logic to save and load selected theme
-Loaded theme from MainActivity, was causing color switching stutter, so added a simple splash screen for startup loading, with the new Compose SplashScreen api
