### PR TITLE
BENCH-27 - Animate cards removal on History screen list

### DIFF
--- a/app/src/main/java/com/epam/caloriecalc/ui/addnew/AddItemScreen.kt
+++ b/app/src/main/java/com/epam/caloriecalc/ui/addnew/AddItemScreen.kt
@@ -46,15 +46,13 @@ fun AddItemScreen(
 
     LaunchedEffect(key1 = true) {
         viewModel.uiEvent.collect { event ->
-            when (event) {
-                is UiEvent.ShowSnackbar -> {
-                    val result = scaffoldState.snackbarHostState.showSnackbar(
-                        message = context.getString(event.messageId, event.itemName),
-                        actionLabel = context.getString(event.action.actionResId)
-                    )
-                    if (result == SnackbarResult.ActionPerformed) {
-                        viewModel.onEvent(AddItemEvent.OnUndoClick)
-                    }
+            if(event is UiEvent.ShowSnackbar) {
+                val result = scaffoldState.snackbarHostState.showSnackbar(
+                    message = context.getString(event.messageId, event.itemName),
+                    actionLabel = context.getString(event.action.actionResId)
+                )
+                if (result == SnackbarResult.ActionPerformed) {
+                    viewModel.onEvent(AddItemEvent.OnUndoClick)
                 }
             }
         }

--- a/app/src/main/java/com/epam/caloriecalc/util/HistoryEvent.kt
+++ b/app/src/main/java/com/epam/caloriecalc/util/HistoryEvent.kt
@@ -5,4 +5,5 @@ import com.epam.caloriecalc.data.model.ProductIntake
 sealed class HistoryEvent {
     data class OnDeleteClick(val productIntake: ProductIntake): HistoryEvent()
     object OnUndoDeleteClick: HistoryEvent()
+    object DeleteFinal: HistoryEvent()
 }

--- a/app/src/main/java/com/epam/caloriecalc/util/UiEvent.kt
+++ b/app/src/main/java/com/epam/caloriecalc/util/UiEvent.kt
@@ -1,12 +1,16 @@
 package com.epam.caloriecalc.util
 
 import com.epam.caloriecalc.R
+import com.epam.caloriecalc.data.local.entities.IntakeRecord
 
 sealed class UiEvent {
     data class ShowSnackbar(
         val messageId: Int,
         val itemName: String? = null,
         val action: SnackbarActionType
+    ) : UiEvent()
+    data class RestoreDeleted(
+        val item: IntakeRecord
     ) : UiEvent()
 }
 


### PR DESCRIPTION
As the official/recommended solution for the LazyColumn item addition/removal animation is not available yet, had to do it with a workaround solution, until that is implemented.

-Modified delete/undo method to wait until the deleted item's Snackbar is dismissed before actual deletion, so the undo animation can be triggered to "re-add" to list at same index with AnimatedVisibility
-On consequent deletions the previous Snackbar is not dismissed, but added to a queue, which causes the undo function to not hold the latest deleted item, so disabled any further deletions until the Snackbar is dismissed (can add a multi-selective deleting function in a later ticket)